### PR TITLE
Switch to Maven Central repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
JCenter is no longer being updated, and has been deprecated by Gradle.